### PR TITLE
Handle shifted characters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,52 @@
+# This config was mostly taken from flycheck/emacs-travis
+# Copyright © 2015 Sebastian Wiesner swiesner@lunaryorn.com
+
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 language: emacs-lisp
-before_install:
-  - if [ "$EMACS" = 'emacs-snapshot' ]; then
-    sudo add-apt-repository -y ppa:cassou/emacs &&
-    sudo apt-get update -qq &&
-    sudo apt-get install -qq
-        emacs-snapshot-el emacs-snapshot-nox;
-    fi
-  - if [ "$EMACS" = 'emacs24' ]; then
-      sudo add-apt-repository -y ppa:cassou/emacs &&
-      sudo apt-get update -qq &&
-      sudo apt-get install -qq
-          emacs24 emacs24-el emacs24-common-non-dfsg;
-    fi
-  - curl -fsSkL https://raw.github.com/rejeep/cask.el/master/go | python
-  - export PATH="$HOME/.cask/bin:$PATH"
-  - cask
-  - $EMACS --version
+sudo: false
+cache:
+  - directories:
+      # Cache stable Emacs binaries (saves 1min per job)
+      - "$HOME/emacs/"
+# Allow Emacs snapshot builds to fail and don’t wait for these as they can take
+# a looooong time
+matrix:
+  fast_finish: true
+  allow_failures:
+    - env: EMACS_VERSION=snapshot
 env:
-  - EMACS=emacs24
+  - EMACS_VERSION=24.5
+  - EMACS_VERSION=25.1
+  - EMACS_VERSION=25.2
+  - EMACS_VERSION=snapshot
+before_install:
+  # Configure $PATH: Executables are installed to $HOME/bin
+  - export PATH="$HOME/bin:$PATH"
+  # Download the makefile to emacs-travis.mk
+  - wget 'https://raw.githubusercontent.com/flycheck/emacs-travis/master/emacs-travis.mk'
+  # Install Emacs (according to $EMACS_VERSION) and Cask
+  - make -f emacs-travis.mk install_emacs
+  - make -f emacs-travis.mk install_cask
+install:
+  - cask install
 script:
-  - cask exec ecukes
+  - cask exec ecukes --no-win

--- a/features/c-commands.feature
+++ b/features/c-commands.feature
@@ -40,6 +40,14 @@ Feature: C- commands
     hubris
     """
 
+  Scenario: execute C-[god-literal-key]
+    Given I bind "C-SPC" to "set-mark-command"
+    And I go to beginning of buffer
+    And I send the key sequence "SPC"
+    And I go to end of buffer
+    And I send the key sequence "u SPC"
+    Then the cursor should be at point "1"
+
   Scenario: execute commands with C-arrow
     Given I bind "C-x C-<left>" to "backward-word"
     And I go to line "1"

--- a/features/c-commands.feature
+++ b/features/c-commands.feature
@@ -54,3 +54,39 @@ Feature: C- commands
     And I go to end of line
     And I send the key sequence "x <left>"
     Then the cursor should be at point "1"
+
+  Scenario: execute commands with uppercase letters (control)
+    Given I bind "C-S-A" to "beginning-of-buffer"
+    And I go to end of buffer
+    And I send the key sequence "A"
+    Then the cursor should be at point "1"
+
+  Scenario: execute commands with uppercase letters (met)
+    Given I bind "M-S-A" to "beginning-of-buffer"
+    And I go to end of buffer
+    And I send the key sequence "g A"
+    Then the cursor should be at point "1"
+
+  Scenario: execute commands with uppercase letters (combination)
+    Given I bind "C-x C-S-A" to "beginning-of-buffer"
+    And I go to end of buffer
+    And I send the key sequence "xA"
+    Then the cursor should be at point "1"
+
+  Scenario: execute commands with shifted arrows (control)
+    Given I bind "C-x C-S-<left>" to "beginning-of-buffer"
+    And I go to end of buffer
+    And I send the key sequence "x S-<left>"
+    Then the cursor should be at point "1"
+
+  Scenario: execute commands with shifted arrows (meta)
+    Given I bind "M-S-<left>" to "beginning-of-buffer"
+    And I go to end of buffer
+    And I send the key sequence "g S-<left>"
+    Then the cursor should be at point "1"
+
+  Scenario: execute commands with shifted arrows (space)
+    Given I bind "C-c S-<left>" to "beginning-of-buffer"
+    And I go to end of buffer
+    And I send the key sequence "C-c S-<left>"
+    Then the cursor should be at point "1"

--- a/features/c-commands.feature
+++ b/features/c-commands.feature
@@ -39,3 +39,10 @@ Feature: C- commands
     impatience
     hubris
     """
+
+  Scenario: execute commands with C-arrow
+    Given I bind "C-x C-<left>" to "backward-word"
+    And I go to line "1"
+    And I go to end of line
+    And I send the key sequence "x <left>"
+    Then the cursor should be at point "1"

--- a/features/c-commands.feature
+++ b/features/c-commands.feature
@@ -12,7 +12,7 @@ Feature: C- commands
 
   Scenario: map k into kill-line
     Given I go to line "1"
-    And I press "kk"
+    And I send the key sequence "kk"
     Then the buffer's contents should be:
     """
     impatience
@@ -21,8 +21,8 @@ Feature: C- commands
 
   Scenario: map / into undo
     Given I go to line "1"
-    And I press "kk"
-    And I press "//"
+    And I send the key sequence "kk"
+    And I send the key sequence "//"
     Then the buffer's contents should be:
     """
     laziness
@@ -33,7 +33,7 @@ Feature: C- commands
   Scenario: execute named keyboard macro
     Given I go to line "1"
     And I bind a named keyboard macro which kills line to C-c C-r
-    And I press "cr"
+    And I send the key sequence "cr"
     Then the buffer's contents should be:
     """
     impatience

--- a/features/digit-arguments.feature
+++ b/features/digit-arguments.feature
@@ -7,9 +7,9 @@ Feature: Digit arguments
     And I go to line "1"
 
   Scenario: M-5 C-d does delete 5 times
-    When I press "M-5 C-d"
+    When I send the key sequence "M-5 C-d"
     Then the buffer's contents should be "fghijklmnopqrstuvwxyz"
 
   Scenario: 5d does delete 5 times
-    When I press "5d"
+    When I send the key sequence "5d"
     Then the buffer's contents should be "fghijklmnopqrstuvwxyz"

--- a/features/insertion-mode.feature
+++ b/features/insertion-mode.feature
@@ -5,9 +5,9 @@ Feature: Insertion mode
     And I am in insertion mode
 
   Scenario: C-u u inserts u 4 times
-    When I press "C-u u"
+    When I send the key sequence "C-u u"
     Then the buffer's contents should be "uuuu"
 
   Scenario: C-u C-u u inserts u 16 times
-    When I press "C-u C-u u"
+    When I send the key sequence "C-u C-u u"
     Then the buffer's contents should be "uuuuuuuuuuuuuuuu"

--- a/features/last-command-event.feature
+++ b/features/last-command-event.feature
@@ -7,9 +7,9 @@ Feature: Prefix arguments
     And I go to line "1"
 
   Scenario: M-4 C-d does delete 4 times
-    When I press "M-4 C-d"
+    When I send the key sequence "M-4 C-d"
     Then the buffer's contents should be "efghijklmnopqrstuvwxyz"
 
   Scenario: g4d does delete 4 times
-    When I press "g4d"
+    When I send the key sequence "g4d"
     Then the buffer's contents should be "efghijklmnopqrstuvwxyz"

--- a/features/predicates-disable.feature
+++ b/features/predicates-disable.feature
@@ -4,7 +4,6 @@ Feature: Predicate based disable
     And I am in buffer "god-mode-test"
     And I describe function "god-mode"
     And I grep current directory
-    And I view the units table
     And I start ielm
 
   Scenario: God mode is automatically enabled for fundamental-mode
@@ -19,8 +18,8 @@ Feature: Predicate based disable
     When I switch to buffer "*grep*"
     Then god-mode is disabled
 
-  Scenario: God mode is disabled in *Units Table* (has view-mode enabled)
-    When I switch to buffer "*Units Table*"
+  Scenario: God mode is disabled in buffers with view-mode
+    When I open a view-mode buffer
     Then god-mode is disabled
 
   Scenario: God mode is disabled in comint derived buffers

--- a/features/predicates-disable.feature
+++ b/features/predicates-disable.feature
@@ -25,3 +25,7 @@ Feature: Predicate based disable
   Scenario: God mode is disabled in comint derived buffers
     When I switch to buffer "*ielm*"
     Then god-mode is disabled
+
+  Scenario: God mode is disabled in mode-class special buffers
+    When I open a test-special-mode buffer
+    Then god-mode is disabled

--- a/features/prefix-arguments.feature
+++ b/features/prefix-arguments.feature
@@ -7,17 +7,17 @@ Feature: Prefix arguments
     And I go to line "1"
 
   Scenario: C-u C-d does delete 4 times
-    When I press "C-u C-d"
+    When I send the key sequence "C-u C-d"
     Then the buffer's contents should be "efghijklmnopqrstuvwxyz"
 
   Scenario: ud does delete 4 times
-    When I press "ud"
+    When I send the key sequence "ud"
     Then the buffer's contents should be "efghijklmnopqrstuvwxyz"
 
   Scenario: C-u C-u C-d does delete 16 times
-    When I press "C-u C-u C-d"
+    When I send the key sequence "C-u C-u C-d"
     Then the buffer's contents should be "qrstuvwxyz"
 
   Scenario: uud does delete 16 times
-    When I press "uud"
+    When I send the key sequence "uud"
     Then the buffer's contents should be "qrstuvwxyz"

--- a/features/repeat.feature
+++ b/features/repeat.feature
@@ -7,17 +7,17 @@ Feature: Repeat
     And I go to line "1"
 
   Scenario: M-5 C-d C-x z does delete 5 times then 5 more times
-    When I press "M-5 C-d C-x z"
+    When I send the key sequence "M-5 C-d C-x z"
     Then the buffer's contents should be "klmnopqrstuvwxyz one two three"
 
   Scenario: 5dx z does delete 5 times then 5 more times
-    When I press "5dx z"
+    When I send the key sequence "5dx SPC z"
     Then the buffer's contents should be "klmnopqrstuvwxyz one two three"
 
   Scenario: M-f C-x z M-d deletes the second word
-    When I press "M-f C-x z M-d"
+    When I send the key sequence "M-f C-x z M-d"
     Then the buffer's contents should be "abcdefghijklmnopqrstuvwxyz one three"
 
   Scenario: gfx zgd deletes the second word
-    When I press "gfx zgd"
+    When I send the key sequence "gfx SPC zgd"
     Then the buffer's contents should be "abcdefghijklmnopqrstuvwxyz one three"

--- a/features/step-definitions/god-mode-steps.el
+++ b/features/step-definitions/god-mode-steps.el
@@ -5,7 +5,7 @@
 (Given "^I bind a named keyboard macro which kills line to C-c C-r$"
   (lambda ()
     (fset 'god-mode-test-keyboard-macro
-          "\C-a\C-k\C-k\C-n\C-n\C-n\C-n\C-n\C-n")
+          "\C-a\C-k\C-k")
     (global-set-key (kbd "C-c C-r") 'god-mode-test-keyboard-macro)))
 
 (Given "^god-mode is enabled for all buffers$"

--- a/features/step-definitions/god-mode-steps.el
+++ b/features/step-definitions/god-mode-steps.el
@@ -30,6 +30,11 @@
          (god-local-mode 0)
          (god-mode-maybe-activate)))
 
+(Given "^I open a test-special-mode buffer"
+       (lambda ()
+         (set-buffer (get-buffer-create "*test-special-mode*"))
+         (test-special-mode)))
+
 (Given "^I start ielm$"
        (lambda ()
          (require 'ielm)

--- a/features/step-definitions/god-mode-steps.el
+++ b/features/step-definitions/god-mode-steps.el
@@ -23,10 +23,12 @@
           (get-buffer-process (grep "grep -Rin god ."))
           nil)))
 
-(Given "^I view the units table$"
+(Given "^I open a view-mode buffer"
        (lambda ()
-         (require 'calc-units)
-         (math-build-units-table-buffer nil)))
+         (set-buffer (get-buffer-create "*view-mode-buffer*"))
+         (view-mode)
+         (god-local-mode 0)
+         (god-mode-maybe-activate)))
 
 (Given "^I start ielm$"
        (lambda ()

--- a/features/step-definitions/god-mode-steps.el
+++ b/features/step-definitions/god-mode-steps.el
@@ -8,6 +8,10 @@
           "\C-a\C-k\C-k")
     (global-set-key (kbd "C-c C-r") 'god-mode-test-keyboard-macro)))
 
+(Given "^I bind \"\\([^\"]+\\)\" to \"\\([^\"]+\\)\""
+  (lambda (key cmd)
+    (local-set-key (kbd key) (intern cmd))))
+
 (Given "^god-mode is enabled for all buffers$"
   (lambda ()
     (when (not god-global-mode)

--- a/features/step-definitions/god-mode-steps.el
+++ b/features/step-definitions/god-mode-steps.el
@@ -39,11 +39,11 @@
 
 (Then "^god-mode is enabled$"
       (lambda ()
-        (assert (not (null god-local-mode)))))
+        (cl-assert (not (null god-local-mode)))))
 
 (Then "^god-mode is disabled$"
       (lambda ()
-        (assert (null god-local-mode))))
+        (cl-assert (null god-local-mode))))
 
 (Then "^I have god-mode on$"
       "Turn god-mode on."
@@ -67,4 +67,4 @@ Examples:
       (lambda (expected)
         (let ((actual (buffer-string))
               (message "Expected buffer's contents to be '%s', but was '%s'"))
-          (assert (s-equals? expected actual) nil message expected actual))))
+          (cl-assert (s-equals? expected actual) nil message expected actual))))

--- a/features/step-definitions/god-mode-steps.el
+++ b/features/step-definitions/god-mode-steps.el
@@ -39,6 +39,10 @@
       (lambda (buffer)
         (switch-to-buffer buffer)))
 
+(When "I send the key sequence \"\\(.+\\)\""
+      (lambda (keys)
+        (execute-kbd-macro (kbd keys))))
+
 (Then "^god-mode is enabled$"
       (lambda ()
         (cl-assert (not (null god-local-mode)))))

--- a/features/support/env.el
+++ b/features/support/env.el
@@ -1,6 +1,17 @@
 (require 'f)
 (require 'cl-lib)
 
+;; From the espuds readme
+(when (and (= emacs-major-version 25))
+  (require 'cl-preloaded)
+  (setf (symbol-function 'cl--assertion-failed)
+        (lambda (form &optional string sargs args)
+          "This function has been modified by ecukes to fix problems with cl-assert in emacs 25.
+           The modified version should only be used for running espuds tests."
+          (if string
+              (apply #'error string (append sargs args))
+            (signal 'cl-assertion-failed `(,form ,@sargs))))))
+
 (defvar god-mode-support-path
   (f-dirname load-file-name))
 

--- a/features/support/env.el
+++ b/features/support/env.el
@@ -1,4 +1,5 @@
 (require 'f)
+(require 'cl-lib)
 
 (defvar god-mode-support-path
   (f-dirname load-file-name))

--- a/features/support/env.el
+++ b/features/support/env.el
@@ -23,6 +23,12 @@
 
 (add-to-list 'load-path god-mode-root-path)
 
+(define-derived-mode test-special-mode fundamental-mode "Test"
+  "This mode is marked special via its mode class rather than
+through inheritance.")
+
+(put 'test-special-mode 'mode-class 'special)
+
 (require 'god-mode)
 (require 'espuds)
 

--- a/god-mode.el
+++ b/god-mode.el
@@ -204,7 +204,8 @@ appropriate). Append to keysequence."
     (message key-string-so-far)
     (setq next-modifier
           (cond
-           ((string= key god-literal-key)
+           ;; If this is the first command, ignore god-literal-sequence
+           ((and key-string-so-far (string= key god-literal-key))
             (setq god-literal-sequence t)
             "")
            (god-literal-sequence

--- a/god-mode.el
+++ b/god-mode.el
@@ -191,6 +191,8 @@ the sequence."
     (?\  "SPC")
     (left "<left>")
     (right "<right>")
+    (S-left "S-<left>")
+    (S-right "S-<right>")
     (prior "<prior>")
     (next "<next>")
     (backspace "DEL")
@@ -224,6 +226,10 @@ appropriate). Append to keysequence."
           (if key-consumed
               (god-mode-sanitized-key-string (read-event key-string-so-far))
             key))
+    (when (and (= (length next-key) 1)
+               (string= (get-char-code-property (aref next-key 0) 'general-category) "Lu"))
+      ;; A single uppercase character indicates that S- was pressed
+      (setq next-modifier (concat next-modifier "S-")))
     (if key-string-so-far
         (concat key-string-so-far " " next-modifier next-key)
       (concat next-modifier next-key))))

--- a/god-mode.el
+++ b/god-mode.el
@@ -270,8 +270,8 @@ Members of the `god-exempt-major-modes' list are exempt."
   (god-mode-child-of-p major-mode 'comint-mode))
 
 (defun god-special-mode-p ()
-  "Return non-nil if major-mode is child of special-mode."
-  (god-mode-child-of-p major-mode 'special-mode))
+  "Return non-nil if major-mode is special or a child of special-mode."
+  (eq (get major-mode 'mode-class) 'special))
 
 (defun god-view-mode-p ()
   "Return non-nil if view-mode is enabled in current buffer."

--- a/god-mode.el
+++ b/god-mode.el
@@ -49,7 +49,7 @@
   :type '(alist))
 
 (defcustom god-literal-key
-  " "
+  "SPC"
   "The key used for literal interpretation."
   :group 'god
   :type 'string)
@@ -179,8 +179,8 @@ recurses. `key-string-so-far' should be nil for the first call in
 the sequence."
   (interactive)
   (let ((sanitized-key
-         (if key-string-so-far (char-to-string (or key (read-event key-string-so-far)))
-           (god-mode-sanitized-key-string (or key (read-event key-string-so-far))))))
+         (god-mode-sanitized-key-string
+          (or key (read-event key-string-so-far)))))
     (god-mode-lookup-command
      (key-string-after-consuming-key sanitized-key key-string-so-far))))
 


### PR DESCRIPTION
This PR comes after #104. When in god-mode, sending an uppercase character should also set the `S-` modifier. Travis results [here](https://travis-ci.org/felipeochoa/god-mode/builds/311135770). This fixes #89