### PR TITLE
Fix keybinding of the "C-c t t t" sort

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,9 @@
 # SOFTWARE.
 
 language: emacs-lisp
-sudo: false
+sudo: required
+dist: trusty
+group: deprecated-2017Q4
 cache:
   - directories:
       # Cache stable Emacs binaries (saves 1min per job)

--- a/features/c-commands.feature
+++ b/features/c-commands.feature
@@ -48,6 +48,12 @@ Feature: C- commands
     And I send the key sequence "u SPC"
     Then the cursor should be at point "1"
 
+  Scenario: execute long sequence of literals
+    Given I bind "C-c b e g" to "beginning-of-buffer"
+    And I go to end of buffer
+    And I send the key sequence "c SPC b e g"
+    Then the cursor should be at point "1"
+
   Scenario: execute commands with C-arrow
     Given I bind "C-x C-<left>" to "backward-word"
     And I go to line "1"

--- a/god-mode.el
+++ b/god-mode.el
@@ -111,6 +111,9 @@ enabled. See also `god-local-mode-resume'."
 (defvar god-global-mode nil
   "Activate God mode on all buffers?")
 
+(defvar god-literal-sequence nil
+  "Activated after space is pressed in a command sequence.")
+
 ;;;###autoload
 (defun god-mode ()
   "Toggle global God mode."
@@ -158,6 +161,7 @@ enabled. See also `god-local-mode-resume'."
     ;; `real-this-command' is used by emacs to populate
     ;; `last-repeatable-command', which is used by `repeat'.
     (setq real-this-command binding)
+    (setq god-literal-sequence nil)
     (if (commandp binding t)
         (call-interactively binding)
       (execute-kbd-macro binding))))
@@ -202,7 +206,10 @@ appropriate). Append to keysequence."
     (message key-string-so-far)
     (cond
      ;; Don't check for god-literal-key with the first key
-     ((and key-string-so-far (string= key god-literal-key)))
+     ((and key-string-so-far (string= key god-literal-key))
+      (setq god-literal-sequence t))
+     (god-literal-sequence
+      (setq key-consumed nil))
      ((and (stringp key) (assoc key god-mod-alist))
       (setq next-modifier (cdr (assoc key god-mod-alist))))
      (t


### PR DESCRIPTION
I broke this in one of the other PRs, but now it's fixed and tested :). This also includes an update to `.travis.yml` since their new architecture broke emacs builds :(

Travis results will be here: https://travis-ci.org/felipeochoa/god-mode/builds/329671385 (the change unfortunately makes it run much slower)
